### PR TITLE
Switch from cassandra to hbase.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ celerybeat-schedule
 *.ipynb
 
 *.pyc
+*.csv.gz
 
 data/
 byn/predict/

--- a/app.Dockerfile
+++ b/app.Dockerfile
@@ -6,7 +6,8 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 COPY byn /byn
 RUN mkdir -p /data/ridge_cache
 
-
+# It looks like a bug in a thrift dependencies. It is not installable without cython.
+RUN pip install cython
 RUN pip install -r /byn/requirements/app.txt
 
 CMD ["python", "-m", "byn.realtime.launch"]

--- a/byn/cassandra_db.py
+++ b/byn/cassandra_db.py
@@ -303,13 +303,13 @@ def _execute_in_parallel(query: str, data: Iterable[Union[Iterable, Dict[str, An
         r.result()
 
 
-def insert_nbrb(data):
+def insert_nbrb_rates(rates: Iterable[dict]):
     _execute_in_parallel(
         'INSERT into nbrb '
         '(dummy, date, usd, eur, rub, uah) '
         'VALUES '
         '(true, %(date)s, %(USD)s, %(EUR)s, %(RUB)s, %(UAH)s) ',
-        data
+        rates
     )
 
 
@@ -339,14 +339,6 @@ def insert_trade_dates(trade_dates: Collection[str]):
     )
 
 
-def insert_nbrb_rates(rates: Iterable[dict]):
-    _execute_in_parallel(
-        'INSERT into nbrb '
-        '(dummy, date, usd, eur, rub, uah) '
-        'VALUES '
-        '(true, %(date)s, %(USD)s, %(EUR)s, %(RUB)s, %(UAH)s) ',
-        rates
-    )
 
 
 def insert_dxy_12MSK(data: Iterable[tuple]):
@@ -407,7 +399,7 @@ def insert_bcse_async(data: Iterable[BcseData], **kwargs):
         'INSERT into bcse (currency, timestamp_operation, timestamp_received, rate) '
         'VALUES (%s, %s, %s, %s)',
         [
-            (row.currency, row.ms_timestamp_operation, row.ms_timestamp_received, row.rate)
+            (row.currency, row.timestamp_operation, row.timestamp_received, row.rate)
             for row in data
         ],
         **kwargs

--- a/byn/cassandra_db.py
+++ b/byn/cassandra_db.py
@@ -3,12 +3,14 @@ import json
 import logging
 import os
 import threading
+import warnings
 from collections import defaultdict
 from dataclasses import asdict
 from decimal import Decimal
 from functools import partial
 from itertools import chain
 from typing import Collection, Iterable, Union, Tuple, Iterator, Any, Dict, Sequence, Optional, List
+
 
 from celery.signals import worker_process_init, worker_process_shutdown
 from cassandra import ConsistencyLevel
@@ -20,6 +22,7 @@ from byn.predict.predictor import PredictionRecord
 from byn.utils import DecimalAwareEncoder, always_on_sync
 
 
+warnings.warn("Cassandra db usage is under deprecation. Use hbase instead.", DeprecationWarning)
 logger = logging.getLogger(__name__)
 
 CASSANDRA_HOSTS = os.environ['CASSANDRA_HOSTS'].split(',')

--- a/byn/commands/cassandra_to_hbase_backup.py
+++ b/byn/commands/cassandra_to_hbase_backup.py
@@ -1,13 +1,14 @@
 import datetime
 import gzip
 import sys
+import csv
 from csv import DictReader, DictWriter
 
 def _cass_ts_to_hbase_ts(cass_ts: str) -> str:
     return str(int(datetime.datetime.strptime(
         cass_ts,
         '%Y-%m-%d %H:%M:%S.%f' if '.' in cass_ts else '%Y-%m-%d %H:%M:%S'
-    ).timestamp()))
+    ).replace(tzinfo=datetime.timezone.utc).timestamp()))
 
 
 def convert_bcse(cassandra_backup_path: str, hbase_backup_path: str):
@@ -46,11 +47,96 @@ def convert_trade_date(cassandra_backup_path: str, hbase_backup_path: str):
             writer.writerow(dict(pairs))
 
 
+def convert_nbrb(official_path: str, global_path: str, hbase_backup_path: str):
+    with gzip.open(hbase_backup_path,mode='wt') as hbase_f:
+        writer = DictWriter(
+            hbase_f,
+            delimiter=';',
+            fieldnames=['key', 'rate:usd', 'rate:eur', 'rate:uah', 'rate:rub', 'rate:dxy']
+        )
+        writer.writeheader()
+
+        with gzip.open(official_path, mode='rt') as official_f:
+            reader = DictReader(official_f, delimiter=';')
+
+            for row in reader:
+                writer.writerow({
+                    'key': f"official|{row['date']}",
+                    'rate:usd': row['usd'],
+                    'rate:eur': row['eur'],
+                    'rate:rub': row['rub'],
+                    'rate:uah': row['uah'],
+                })
+
+        with gzip.open(global_path, mode='rt') as global_f:
+            reader = DictReader(global_f, delimiter=';')
+
+            for row in reader:
+                writer.writerow({
+                    'key': f"global|{row['date']}",
+                    'rate:dxy': row['dxy'],
+                })
+
+
+def convert_external_rate_live(cassandra_backup_path: str, hbase_backup_path: str):
+    key_columns = 'currency', 'timestamp_open', 'volume',
+    data_columns = 'close', 'timestamp_received',
+
+    with gzip.open(cassandra_backup_path, mode='rt') as cass_f, gzip.open(hbase_backup_path, mode='wt') as hbase_f:
+        reader = csv.reader(cass_f, delimiter=',')
+        writer = DictWriter(
+            hbase_f,
+            fieldnames=['key', *('rate:' + x for x in data_columns)],
+            delimiter=';'
+        )
+        writer.writeheader()
+
+        for row in reader:
+            ts_open = _cass_ts_to_hbase_ts(row[1][:-5])
+            ts_received = _cass_ts_to_hbase_ts(row[4][:-5])
+
+            writer.writerow({
+                'key': f'{row[0]}|{ts_open}|{row[2]}',
+                'rate:close': row[3],
+                'rate:timestamp_received': ts_received,
+            })
+
+
+def convert_external_rate(cassandra_backup_path: str, hbase_backup_path: str):
+    key_columns = ['currency', 'year', 'datetime']
+    data_columns = ['close', 'high', 'low', 'open', 'volume']
+
+    with gzip.open(cassandra_backup_path, mode='rt') as cass_f, gzip.open(hbase_backup_path, mode='wt') as hbase_f:
+        reader = DictReader(
+            cass_f,
+            delimiter=',',
+            fieldnames=key_columns + data_columns,
+        )
+        writer = DictWriter(
+            hbase_f,
+            fieldnames=['key', *('rate:' + x for x in data_columns)],
+            delimiter=';'
+        )
+        writer.writeheader()
+
+        for row in reader:
+            ts_open = _cass_ts_to_hbase_ts(row['datetime'][:-5])
+            pairs = [('key', f"{row['currency']}|{ts_open}")]
+            pairs.extend(('rate:' + x, row.get(x)) for x in data_columns)
+            writer.writerow(dict(pairs))
+
+
 if __name__ == '__main__':
     if sys.argv[1] == 'bcse':
         convert_bcse(*sys.argv[2:])
     elif sys.argv[1] == 'trade_date':
         convert_trade_date(*sys.argv[2:])
+    elif sys.argv[1] == 'nbrb':
+        convert_nbrb(*sys.argv[2:])
+    elif sys.argv[1] == 'external_rate_live':
+        convert_external_rate_live(*sys.argv[2:])
+    elif sys.argv[1] == 'external_rate':
+        convert_external_rate(*sys.argv[2:])
     else:
         raise ValueError(sys.argv[0])
 

--- a/byn/commands/cassandra_to_hbase_backup.py
+++ b/byn/commands/cassandra_to_hbase_backup.py
@@ -10,10 +10,15 @@ def _cass_ts_to_hbase_ts(cass_ts: str) -> str:
     ).timestamp()))
 
 
-def conver_bcse(cassandra_backup_path: str, hbase_backup_path: str):
+def convert_bcse(cassandra_backup_path: str, hbase_backup_path: str):
     with gzip.open(cassandra_backup_path, mode='rt') as cass_f, gzip.open(hbase_backup_path, mode='wt') as hbase_f:
         reader = DictReader(cass_f, delimiter=';')
-        writer = DictWriter(hbase_f, fieldnames=['key', 'rate:timestamp_received', 'rate:rate'], delimiter=';')
+        writer = DictWriter(
+            hbase_f,
+            fieldnames=['key', 'rate:timestamp_received', 'rate:rate'],
+            delimiter=';'
+        )
+        writer.writeheader()
 
         for row in reader:
             writer.writerow({
@@ -25,7 +30,7 @@ def conver_bcse(cassandra_backup_path: str, hbase_backup_path: str):
 
 if __name__ == '__main__':
     if sys.argv[1] == 'bcse':
-        conver_bcse(*sys.argv[2:])
+        convert_bcse(*sys.argv[2:])
     else:
         raise ValueError(sys.argv[0])
 

--- a/byn/commands/cassandra_to_hbase_backup.py
+++ b/byn/commands/cassandra_to_hbase_backup.py
@@ -1,0 +1,32 @@
+import datetime
+import gzip
+import sys
+from csv import DictReader, DictWriter
+
+def _cass_ts_to_hbase_ts(cass_ts: str) -> str:
+    return str(int(datetime.datetime.strptime(
+        cass_ts,
+        '%Y-%m-%d %H:%M:%S.%f' if '.' in cass_ts else '%Y-%m-%d %H:%M:%S'
+    ).timestamp()))
+
+
+def conver_bcse(cassandra_backup_path: str, hbase_backup_path: str):
+    with gzip.open(cassandra_backup_path, mode='rt') as cass_f, gzip.open(hbase_backup_path, mode='wt') as hbase_f:
+        reader = DictReader(cass_f, delimiter=';')
+        writer = DictWriter(hbase_f, fieldnames=['key', 'rate:timestamp_received', 'rate:rate'], delimiter=';')
+
+        for row in reader:
+            writer.writerow({
+                'key': f'{row["currency"]}|{_cass_ts_to_hbase_ts(row["timestamp_operation"])}',
+                'rate:timestamp_received': _cass_ts_to_hbase_ts(row['timestamp_received']),
+                'rate:rate': row['rate'],
+            })
+
+
+if __name__ == '__main__':
+    if sys.argv[1] == 'bcse':
+        conver_bcse(*sys.argv[2:])
+    else:
+        raise ValueError(sys.argv[0])
+
+

--- a/byn/commands/create_hbase_db.py
+++ b/byn/commands/create_hbase_db.py
@@ -11,3 +11,7 @@ def run():
         connection.create_table('bcse', {'rate': {}})
         connection.create_table('prediction', {'rate': {}})
 
+
+if __name__ == '__main__':
+    run()
+

--- a/byn/commands/create_hbase_db.py
+++ b/byn/commands/create_hbase_db.py
@@ -1,0 +1,13 @@
+from byn.hbase_db import db
+
+
+def run():
+    with db.connection() as connection:
+        connection.create_table('nbrb', {'rate': {}})
+        connection.create_table('rolling_average', {'rate': {}})
+        connection.create_table('trade_date', {'rate': {}})
+        connection.create_table('external_rate', {'rate': {}})
+        connection.create_table('external_rate_live', {'rate': {}})
+        connection.create_table('bcse', {'rate': {}})
+        connection.create_table('prediction', {'rate': {}})
+

--- a/byn/commands/create_hbase_db.py
+++ b/byn/commands/create_hbase_db.py
@@ -3,13 +3,24 @@ from byn.hbase_db import db
 
 def run():
     with db.connection() as connection:
-        connection.create_table('nbrb', {'rate': {}})
-        connection.create_table('rolling_average', {'rate': {}})
-        connection.create_table('trade_date', {'rate': {}})
-        connection.create_table('external_rate', {'rate': {}})
-        connection.create_table('external_rate_live', {'rate': {}})
-        connection.create_table('bcse', {'rate': {}})
-        connection.create_table('prediction', {'rate': {}})
+        existing_tables = [x.decode() for x in connection.tables()]
+        tables_to_create = (
+            'nbrb',
+            'rolling_average',
+            'trade_date',
+            'external_rate',
+            'external_rate_live',
+            'bcse',
+            'prediction',
+        )
+
+        for table_name in tables_to_create:
+            if table_name in existing_tables:
+                print(f'{table_name} already exists')
+                continue
+
+            connection.create_table(table_name, {'rate': {}})
+            print(f'{table_name} created.')
 
 
 if __name__ == '__main__':

--- a/byn/commands/drop_hbase_tables.py
+++ b/byn/commands/drop_hbase_tables.py
@@ -5,8 +5,15 @@ from byn.hbase_db import db
 
 def run(*table_names: str):
     with db.connection() as connection:
-        for table in table_names:
-            connection.delete_table(table, disable=True)
+        tables = [x.decode() for x in connection.tables()]
+
+        for table_name in table_names:
+            if table_name not in tables:
+                print(f'{table_name} does not exist.')
+                continue
+
+            connection.delete_table(table_name, disable=True)
+            print(f'{table_name} is deleted.')
 
 
 if __name__ == '__main__':

--- a/byn/commands/drop_hbase_tables.py
+++ b/byn/commands/drop_hbase_tables.py
@@ -1,0 +1,13 @@
+import sys
+
+from byn.hbase_db import db
+
+
+def run(*table_names: str):
+    with db.connection() as connection:
+        for table in table_names:
+            connection.delete_table(table, disable=True)
+
+
+if __name__ == '__main__':
+    run(*sys.argv[1:])

--- a/byn/commands/restore_hbase_table.py
+++ b/byn/commands/restore_hbase_table.py
@@ -1,14 +1,11 @@
 import csv
 import gzip
+import sys
 
 from byn.hbase_db import table
 
 
-def run(table_name: str, path: str, override: str):
-    if override != '--override':
-        raise ValueError('Please, provide --override key to be sure you understand that all existing data will be nuked.')
-
-
+def run(table_name: str, path: str):
     if path.endswith('.csv'):
         _open = open
     elif path.endswith('.csv.gz'):
@@ -18,7 +15,11 @@ def run(table_name: str, path: str, override: str):
 
     with _open(path, mode='rt') as f, table(table_name) as the_table:
         with the_table.batch(batch_size=100) as batch:
-            for row in csv.DictReader(f):
+            for row in csv.DictReader(f, delimiter=';'):
                 key = row.pop('key').encode()
                 data = {column.encode(): value for column, value in row.items() if value}
                 batch.put(key, data)
+
+
+if __name__ == '__main__':
+    run(sys.argv[1], sys.argv[2])

--- a/byn/commands/restore_hbase_table.py
+++ b/byn/commands/restore_hbase_table.py
@@ -1,0 +1,24 @@
+import csv
+import gzip
+
+from byn.hbase_db import table
+
+
+def run(table_name: str, path: str, override: str):
+    if override != '--override':
+        raise ValueError('Please, provide --override key to be sure you understand that all existing data will be nuked.')
+
+
+    if path.endswith('.csv'):
+        _open = open
+    elif path.endswith('.csv.gz'):
+        _open = gzip.open
+    else:
+        raise ValueError('Unexpected dump file extension: %s' % path)
+
+    with _open(path, mode='rt') as f, table(table_name) as the_table:
+        with the_table.batch(batch_size=100) as batch:
+            for row in csv.DictReader(f):
+                key = row.pop('key').encode()
+                data = {column.encode(): value for column, value in row.items() if value}
+                batch.put(key, data)

--- a/byn/datatypes.py
+++ b/byn/datatypes.py
@@ -21,8 +21,8 @@ class ExternalRateData:
 @dataclass
 class BcseData:
     currency: str
-    ms_timestamp_operation: int
-    ms_timestamp_received: int
+    timestamp_operation: int
+    timestamp_received: int
     rate: str
 
 

--- a/byn/happybase_retryable.py
+++ b/byn/happybase_retryable.py
@@ -2,32 +2,58 @@ import logging
 
 import happybase.connection
 import happybase.pool
+import happybase.table
 from happybase.connection import Connection
 from happybase.table import Table
+from happybase.batch import Batch
 
-from byn.utils import retryable
+from byn.retry import retryable, retryable_generator
 
 
 logger = logging.getLogger(__name__)
 
 
-FAILABLE_CONNECTION_METHODS = 'tables', 'create_table',  'enable_table', 'disable_table', 'is_table_enabled', 'compact_table'
-FAILABLE_TABLE_METHODS = 'counter_inc', 'delete', 'put', 'scan', 'cells', 'row', 'rows', 'families'
+class RetryableMixin:
+    FAILABLE_SYNC_METHODS = ()
+    FAILABLE_GENERATOR_METHODS = ()
 
+    def _retry_callback(self, *args, **kwargs):
+        pass
 
-class RetryableConnection(Connection):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        for field_name in FAILABLE_CONNECTION_METHODS:
+        for field_name in self.FAILABLE_SYNC_METHODS:
             setattr(
                 self,
                 field_name,
                 retryable(
-                    getattr(super(RetryableConnection, self), field_name),
+                    getattr(super(), field_name),
                     expected_exception=Exception,
-                    callback=self.reset_client
+                    callback=self._retry_callback
                 )
             )
+
+        for field_name in self.FAILABLE_GENERATOR_METHODS:
+            setattr(
+                self,
+                field_name,
+                retryable_generator(
+                    getattr(super(), field_name),
+                    expected_exception=Exception,
+                    callback=self._retry_callback
+                )
+            )
+
+
+class RetryableConnection(RetryableMixin, Connection):
+    FAILABLE_SYNC_METHODS = (
+        'tables', 'create_table',
+        'enable_table', 'disable_table',
+        'is_table_enabled', 'compact_table'
+    )
+
+    def _retry_callback(self, *args, **kwargs):
+        self.reset_client()
 
     def reset_client(self, *args, **kwargs):
         logger.info('Refreshng the connection %s', self)
@@ -36,25 +62,25 @@ class RetryableConnection(Connection):
         logger.info('Connection %s is refreshed', self)
 
 
-class RetryableTable(Table):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        for field_name in FAILABLE_TABLE_METHODS:
-            original_method = getattr(super(RetryableTable, self), field_name)
+class RetryableTable(RetryableMixin, Table):
+    def _retry_callback(self, *args, **kwargs):
+        self.connection.reset_client()
 
-            setattr(
-                self,
-                field_name,
-                retryable(
-                    original_method,
-                    expected_exception=Exception,
-                    callback=self.connection.reset_client
-                )
-            )
+    FAILABLE_SYNC_METHODS = 'counter_inc', 'cells', 'row', 'rows', 'families'
+    FAILABLE_GENERATOR_METHODS = 'scan',
+
+
+
+class RetryableBatch(RetryableMixin, Batch):
+    FAILABLE_SYNC_METHODS = 'send',
+
+    def _retry_callback(self, *args, **kwargs):
+        self._table.connection.reset_client()
 
 
 def monkeypatch_happybase():
     happybase.connection.Connection = RetryableConnection
     happybase.pool.Connection = RetryableConnection
     happybase.connection.Table = RetryableTable
+    happybase.table.Batch = RetryableBatch
     logger.info('happybase is monkeypatched!')

--- a/byn/happybase_retryable.py
+++ b/byn/happybase_retryable.py
@@ -1,0 +1,60 @@
+import logging
+
+import happybase.connection
+import happybase.pool
+from happybase.connection import Connection
+from happybase.table import Table
+
+from byn.utils import retryable
+
+
+logger = logging.getLogger(__name__)
+
+
+FAILABLE_CONNECTION_METHODS = 'tables', 'create_table',  'enable_table', 'disable_table', 'is_table_enabled', 'compact_table'
+FAILABLE_TABLE_METHODS = 'counter_inc', 'delete', 'put', 'scan', 'cells', 'row', 'rows', 'families'
+
+
+class RetryableConnection(Connection):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        for field_name in FAILABLE_CONNECTION_METHODS:
+            setattr(
+                self,
+                field_name,
+                retryable(
+                    getattr(super(RetryableConnection, self), field_name),
+                    expected_exception=Exception,
+                    callback=self.reset_client
+                )
+            )
+
+    def reset_client(self, *args, **kwargs):
+        logger.info('Refreshng the connection %s', self)
+        self._refresh_thrift_client()
+        self.open()
+        logger.info('Connection %s is refreshed', self)
+
+
+class RetryableTable(Table):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        for field_name in FAILABLE_TABLE_METHODS:
+            original_method = getattr(super(RetryableTable, self), field_name)
+
+            setattr(
+                self,
+                field_name,
+                retryable(
+                    original_method,
+                    expected_exception=Exception,
+                    callback=self.connection.reset_client
+                )
+            )
+
+
+def monkeypatch_happybase():
+    happybase.connection.Connection = RetryableConnection
+    happybase.pool.Connection = RetryableConnection
+    happybase.connection.Table = RetryableTable
+    logger.info('happybase is monkeypatched!')

--- a/byn/hbase_db.py
+++ b/byn/hbase_db.py
@@ -1,5 +1,6 @@
 import datetime
 import json
+import logging
 import os
 import threading
 from collections import defaultdict, OrderedDict
@@ -20,11 +21,16 @@ from byn.utils import DecimalAwareEncoder, always_on_sync
 
 
 thread_local = threading.local()
+logger = logging.getLogger(__name__)
 
 @always_on_sync
 def _get_pool():
-    print('Pool initialized!')
-    return happybase.ConnectionPool(size=4, host=os.environ['HBASE_HOST'], timeout=5000, protocol='binary')
+    if 'HBASE_HOST' in os.environ:
+        logger.debug('Pool initialized!')
+        return happybase.ConnectionPool(size=4, host=os.environ['HBASE_HOST'], timeout=5000, protocol='binary')
+    else:
+        logger.debug("Pool won't be initialized.")
+        return None
 
 
 

--- a/byn/hbase_db.py
+++ b/byn/hbase_db.py
@@ -305,13 +305,13 @@ def get_accumulated_error(date: datetime.date):
                 reverse=True,
                 limit=1,
                 columns=[b'rate:accumulated_error'],
-                filter="SingleColumnValueFilter('rate', 'accumulated_error', >, 'binary:', true)",
+                filter="SingleColumnValueFilter('rate', 'accumulated_error', >, 'binary:', true, true)",
                 row_start=date_to_bytes(date)
             ),
             None
         )
 
-    return record and get_decimal(record[0], b'rate:accumulated_error')
+    return record and get_decimal(record[1], b'rate:accumulated_error')
 
 
 ############## INSERT ############

--- a/byn/hbase_db.py
+++ b/byn/hbase_db.py
@@ -282,7 +282,7 @@ def get_the_last_external_rates(currencies: Iterable[str], end_dt: datetime.date
         for currency in currencies:
             currency_to_data[currency] = _parse_external_rate_row(
                 *next(external_rate.scan(
-                    row_start=f'{currency}|{int(end_dt.timestamp()) - 1}'.encode(),
+                    row_start=f'{currency}|{int(end_dt.timestamp())}'.encode(),
                     reverse=True,
                     limit=1
                 ))

--- a/byn/hbase_db.py
+++ b/byn/hbase_db.py
@@ -15,13 +15,17 @@ from celery.signals import worker_process_init
 from happybase.util import bytes_increment
 from happybase.pool import ConnectionPool
 
+import byn.logging
 from byn.datatypes import ExternalRateData, BcseData
+from byn.happybase_retryable import monkeypatch_happybase
 from byn.predict.predictor import PredictionRecord
 from byn.utils import DecimalAwareEncoder, always_on_sync
 
 
+monkeypatch_happybase()
 thread_local = threading.local()
 logger = logging.getLogger(__name__)
+
 
 @always_on_sync
 def _get_pool():

--- a/byn/hbase_db.py
+++ b/byn/hbase_db.py
@@ -1,6 +1,7 @@
 import datetime
 import json
 import os
+from collections import defaultdict, OrderedDict
 from contextlib import contextmanager
 from dataclasses import asdict
 from decimal import Decimal
@@ -107,6 +108,173 @@ def get_nbrb_gt(date: Optional[datetime.date], kind: NbrbKind):
     with table('nbrb') as nbrb:
         return nbrb.scan(row_start=kind.as_prefix + start_date_part)
 
+def get_bcse_in(
+        currency: str,
+        start_dt: datetime.datetime,
+        end_dt: datetime.datetime = None
+) -> Iterable[Tuple[int, Decimal]]:
+    start_dt = int(start_dt.timestamp())
+    end_dt = int((end_dt or datetime.datetime(2035, 1, 1)).timestamp())
+
+    with table('bcse') as bcse:
+        key_data_pairs = bcse.scan(
+            row_start=f'{currency}|{start_dt}'.encode(),
+            row_stop=f'{currency}|{end_dt}'.encode()
+        )
+
+    return (
+        (int(key_part(key, 1)), get_decimal(data, b'rate:rate'))
+        for key, data in key_data_pairs
+    )
+
+
+def get_external_rate_live(start_dt: datetime.datetime,
+                           end_dt: Optional[datetime.datetime] = None) -> Dict[
+    str, Iterable[Tuple[int, Decimal]]]:
+    # Making 4 parallel requests in cassandra fitted this case better...
+
+    end_dt = end_dt or datetime.datetime(2100, 1, 1)
+    currencies = 'EUR', 'RUB', 'UAH', 'DXY'
+
+    data = {}
+    with table('external_rate_live') as external_rate_live:
+
+        for currency in currencies:
+            # Get the data.
+            rows = external_rate_live.scan(
+                row_start=f'{currency}|{int(start_dt.timestamp())}|'.encode(),
+                row_stop=f'{currency}|{int(end_dt.timestamp())}|'.encode(),
+            )
+            # Decode what we got.
+            rows = [{
+                'ts_open': int(key_part(key, 1)),
+                'ts_received': int(value[b'rate:timestamp_received']),
+                'rate': get_decimal(value, b'rate:close'),
+            } for key, value in rows]
+
+            # Create close timestamps.
+            open_to_close = OrderedDict()
+            prev_key = None
+            for row in rows:
+                if row['ts_open'] not in open_to_close:
+                    open_to_close[prev_key] = row['ts_open']
+
+            # Set data with correct timestamps.
+            data[currency] = tuple(
+                (
+                    _choose_real_time_for_live_event(
+                        row['ts_open'],
+                        row['ts_received'],
+                        open_to_close.get(row['ts_received'])
+                    ),
+                    row['rate']
+                ) for row in rows
+            )
+
+    return data
+
+
+
+def _choose_real_time_for_live_event(
+        timestamp_open: int,
+        timestamp_received: int,
+        timestamp_close: Optional[int]
+):
+    left_boundary = max(timestamp_open, timestamp_received)
+    return min(left_boundary, timestamp_close - 1) if timestamp_close is not None else left_boundary
+
+
+def get_latest_external_rates(
+        start_dt: datetime.datetime,
+        *,
+        at_least_one: bool = False
+) -> Dict[str, Iterable[list]]:
+
+
+    currencies = 'EUR', 'RUB', 'UAH', 'DXY'
+    currency_to_rows = defaultdict(list)
+
+
+    if at_least_one:
+        last_data = get_the_last_external_rates(currencies, end_dt=start_dt)
+        for currency, row in last_data.items():
+            currency_to_rows[currency].append(row)
+
+
+    with table('external_rate') as external_rate:
+        for currency in currencies:
+            rows = external_rate.scan(
+                row_start=f'{currency}|{int(start_dt.timestamp())}'.encode()
+            )
+
+            currency_to_rows[currency].extend(_parse_external_rate_row(*x) for x in rows)
+
+
+    return {
+        currency: _external_rate_data_into_pairs(currency_to_rows[currency])
+        for currency in currencies
+    }
+
+
+def _external_rate_data_into_pairs(rates: Sequence[dict]):
+    pairs = []
+
+    for i in range(len(rates) - 1):
+        pairs.append((
+            rates[i]['ts_open'],
+            rates[i]['rate_open'],
+        ))
+        pairs.append((
+            rates[i+1]['ts_open'] - 1,
+            rates[i]['rate_close'],
+        ))
+
+    pairs.append((
+        rates[-1]['ts_open'],
+        rates[-1]['rate_open'],
+    ))
+
+    return pairs
+
+
+def get_the_last_external_rates(currencies: Iterable[str], end_dt: datetime.datetime) -> Dict[str, dict]:
+    currency_to_data = {}
+
+    with table('external_rate') as external_rate:
+        for currency in currencies:
+            currency_to_data[currency] = _parse_external_rate_row(
+                *external_rate.scan(
+                    row_start=f'{currency}|{int(end_dt.timestamp()) - 1}'.encode(),
+                    reverse=True,
+                    limit=1
+                )[0]
+            )
+
+    return currency_to_data
+
+
+def _parse_external_rate_row(key, value):
+    return {
+        'ts_open': key_part(key, 1),
+        'rate_open': get_decimal(value, b'rate:open'),
+        'rate_close': get_decimal(value, b'rate:close'),
+    }
+
+
+def get_accumulated_error(date: datetime.date):
+    with table('trade_date') as trade_date:
+        record = next(
+            trade_date.scan(
+                reverse=True,
+                limit=1,
+                columns=[b'rate:accumulated_error'],
+                filter="SingleColumnValueFilter('rate', 'accumulated_error', >, '', true)",
+                row_start=date_to_bytes(date)
+            ),
+            None
+        )
+
+    return record and get_decimal(record[0], b'rate:accumulated_error')
 
 
 ############## INSERT ############

--- a/byn/hbase_db.py
+++ b/byn/hbase_db.py
@@ -67,7 +67,7 @@ class NbrbKind(Enum):
 
 
 ############# SELECT ############
-def get_last_nbrb_record(kind: NbrbKind) -> Tuple[bytes, Dict[bytes: bytes]]:
+def get_last_nbrb_record(kind: NbrbKind) -> Tuple[bytes, Dict[bytes, bytes]]:
     with table('nbrb') as nbrb:
         return next(iter(nbrb.scan(reverse=True, limit=1, row_prefix=kind.as_prefix)), None)
 

--- a/byn/hbase_db.py
+++ b/byn/hbase_db.py
@@ -1,0 +1,211 @@
+import datetime
+import json
+import os
+from contextlib import contextmanager
+from dataclasses import asdict
+from decimal import Decimal
+from typing import Collection, Dict, Iterable, Iterator, Sequence, Tuple
+
+import happybase
+
+from byn.datatypes import ExternalRateData, BcseData
+from byn.predict.predictor import PredictionRecord
+from byn.utils import DecimalAwareEncoder
+
+db = happybase.ConnectionPool(size=4, host=os.environ['HBASE_HOST'])
+
+
+@contextmanager
+def table(name: str):
+    with db.connection() as connection:
+        yield connection.table(name)
+
+
+DATE_FORMAT = '%Y-%m-%d'
+
+
+def next_date_to_string(date: datetime.date) -> str:
+    return (date + datetime.timedelta(days=1)).strftime(DATE_FORMAT)
+
+
+def next_date_to_bytes(date: datetime.date) -> bytes:
+    return next_date_to_string(date).encode()
+
+
+def date_to_bytes(date: datetime.date) -> bytes:
+    return date.strftime(DATE_FORMAT).encode()
+
+
+def bytes_to_date(data: bytes) -> datetime.date:
+    return datetime.datetime.strptime(data.decode(), DATE_FORMAT).date()
+
+
+def key_part(key: bytes, index: int) -> bytes:
+    return key.split(b'|')[index]
+
+
+def key_part_as_date(key: bytes, index: int) -> datetime.date:
+    return bytes_to_date(key_part(key, index))
+
+
+def get_decimal(row: dict, column: bytes) -> Decimal:
+    return Decimal(row[column].decode())
+
+
+############## INSERT ############
+
+def _put_in_batch(
+        table_name: str,
+        key_to_data: Dict[bytes, Dict[bytes, bytes]],
+        *,
+        prefix: bytes=b'',
+        transaction=True,
+):
+    with table(table_name) as a_table:
+        with a_table.batch(transaction=True) as batch:
+            for key, data in key_to_data.items():
+                batch.put(prefix + key, data)
+
+
+def insert_nbrb(data):
+    data = {
+        date_to_bytes(x['date']):
+        {
+            b'rate:usd': str(x['USD']).encode(),
+            b'rate:eur': str(x['EUR']).encode(),
+            b'rate:rub': str(x['RUB']).encode(),
+            b'rate:uah': str(x['UAH']).encode(),
+        }
+        for x in data
+    }
+    _put_in_batch('nbrb', data, prefix=b'official|')
+
+
+
+def insert_nbrb_local(data):
+    data = {
+        date_to_bytes(x['date']):
+            {
+                b'rate:usd': str(x['USD']).encode(),
+                b'rate:eur': str(x['EUR']).encode(),
+                b'rate:rub': str(x['RUB']).encode(),
+                b'rate:uah': str(x['UAH']).encode(),
+            }
+        for x in data
+    }
+    _put_in_batch('nbrb', data, prefix=b'local|')
+
+
+def add_nbrb_global(data):
+    data = {
+        date_to_bytes(x['date']):
+            {
+                b'rate:byn': str(x['BYN']).encode(),
+                b'rate:eur': str(x['EUR']).encode(),
+                b'rate:rub': str(x['RUB']).encode(),
+                b'rate:uah': str(x['UAH']).encode(),
+            }
+        for x in data
+    }
+    _put_in_batch('nbrb', data, prefix=b'local|')
+
+
+def insert_trade_dates(trade_dates: Collection[str]):
+    _put_in_batch('trade_date', {x.encode(): {} for x in trade_dates})
+
+
+def insert_dxy_12MSK(data: Iterable[Tuple[str ,str]]):
+    data = {
+        date.encode(): dxy.encode
+        for date, dxy in data
+    }
+    _put_in_batch('nbrb', data, prefix=b'global|')
+
+
+def insert_external_rates(
+        currency: str,
+        data: Iterator[
+            Tuple[
+                datetime.datetime,
+                Decimal,
+                Decimal,
+                Decimal,
+                Decimal,
+                int
+            ]
+        ]
+):
+    data = {
+        f'{currency}|{record[0]}'.encode(): {
+            b'rate:open': record[1],
+            b'rate:close': record[2],
+            b'rate:low': record[3],
+            b'rate:high': record[4],
+
+        }
+        for record in data
+    }
+
+    _put_in_batch('external_rate', key_to_data=data)
+
+
+
+def insert_external_rate_live(row: ExternalRateData):
+    with table('external_rate_live') as external_rate_live:
+        external_rate_live.put(f'{row.currency}|{row.timestamp_open}|{row.volume}'.encode(), {
+            b'rate:timestamp_received': str(row.timestamp_received).encode(),
+            b'rate:close': str(row.close).encode(),
+        })
+
+
+
+def insert_bcse(data: Iterable[BcseData], **kwargs):
+    data = {
+        f'{x.currency}|{x.timestamp_operation}'.encode(): {
+            b'rate:timestamp_received': x.timestamp_received,
+            b'rate:rate': x.rate,
+        }
+        for x in data
+    }
+
+    _put_in_batch('bcse', key_to_data=data)
+
+
+def insert_prediction(
+        *,
+        timestamp: int,
+        external_rates: Dict[str, str],
+        bcse_full: Sequence[Sequence],
+        bcse_trusted_global: Sequence[Sequence],
+        prediction: PredictionRecord
+):
+    if bcse_full is not None:
+        bcse_full = _ndarray_to_tuple_of_tuples(bcse_full)
+
+    if bcse_trusted_global is not None:
+        bcse_trusted_global = _ndarray_to_tuple_of_tuples(bcse_trusted_global)
+
+    with table('prediction') as prediction_table:
+        prediction_table.put(str(timestamp).encode(), {
+            b'rate:external_rates': json.dumps(external_rates, cls=DecimalAwareEncoder).encode(),
+            b'rate:bcse_full': json.dumps(bcse_full, cls=DecimalAwareEncoder).encode(),
+            b'rate:bcse_trusted_global': json.dumps(bcse_trusted_global, cls=DecimalAwareEncoder).encode(),
+            b'rate:prediction': json.dumps(asdict(prediction), cls=DecimalAwareEncoder).encode(),
+        })
+
+
+def insert_rolling_average(date: datetime.date, duration: int, data: Sequence[Decimal]):
+    with table('rolling_average') as rolling_average:
+        key = date_to_bytes(date) + b'|' + str(duration).encode()
+        rolling_average.put(key, {
+            b'rate:eur': data[0],
+            b'rate:rub': data[1],
+            b'rate:uah': data[2],
+            b'rate:dxy': data[3],
+        })
+
+
+def _ndarray_to_tuple_of_tuples(numpy_array):
+    return tuple(tuple(row) for row in numpy_array)
+
+

--- a/byn/hbase_db.py
+++ b/byn/hbase_db.py
@@ -10,7 +10,7 @@ from typing import Collection, Dict, Iterable, Iterator, Optional, Sequence, Tup
 from enum import Enum
 
 import happybase
-from celery.signals import worker_process_init, worker_process_shutdown
+from celery.signals import worker_process_init
 from happybase.util import bytes_increment
 from happybase.pool import ConnectionPool
 
@@ -280,11 +280,11 @@ def get_the_last_external_rates(currencies: Iterable[str], end_dt: datetime.date
     with table('external_rate') as external_rate:
         for currency in currencies:
             currency_to_data[currency] = _parse_external_rate_row(
-                *external_rate.scan(
+                *next(external_rate.scan(
                     row_start=f'{currency}|{int(end_dt.timestamp()) - 1}'.encode(),
                     reverse=True,
                     limit=1
-                )[0]
+                ))
             )
 
     return currency_to_data

--- a/byn/hbase_db.py
+++ b/byn/hbase_db.py
@@ -390,22 +390,22 @@ def insert_external_rates(
         currency: str,
         data: Iterator[
             Tuple[
-                datetime.datetime,
-                Decimal,
-                Decimal,
-                Decimal,
-                Decimal,
+                int,
+                str,
+                str,
+                str,
+                str,
                 int
             ]
         ]
 ):
     data = {
         f'{currency}|{record[0]}'.encode(): {
-            b'rate:open': record[1],
-            b'rate:close': record[2],
-            b'rate:low': record[3],
-            b'rate:high': record[4],
-
+            b'rate:open': record[1].encode(),
+            b'rate:close': record[2].encode(),
+            b'rate:low': record[3].encode(),
+            b'rate:high': record[4].encode(),
+            b'rate:volume': str(record[5]).encode(),
         }
         for record in data
     }

--- a/byn/predict_utils.py
+++ b/byn/predict_utils.py
@@ -18,6 +18,7 @@ from byn.hbase_db import (
     key_part,
     get_decimal,
     get_accumulated_error,
+    NbrbKind,
 )
 
 
@@ -81,8 +82,8 @@ def _get_X_Y_with_empty_rolling(date: datetime.date) -> Tuple[np.ndarray, np.nda
     with table('nbrb') as nbrb_table:
         keys, rates = zip(
             *nbrb_table.scan(
-                row_start=b'global|',
-                row_stop=b'global|' + date_to_next_bytes(date)
+                row_start=NbrbKind.GLOBAL.as_prefix,
+                row_stop=NbrbKind.GLOBAL.as_prefix + date_to_next_bytes(date)
             )
         )
 

--- a/byn/predict_utils.py
+++ b/byn/predict_utils.py
@@ -60,7 +60,7 @@ def _get_full_X_Y(date: datetime.date) -> Tuple[np.ndarray, np.ndarray, Tuple[da
 
     for key, data in rolling_averages:
         date, duration = key.split(b'|')
-        rolling_averages_as_dict[date][duration] = data.values()
+        rolling_averages_as_dict[date][duration] = [data[column] for column in EXTERNAL_RATES_COLUMNS]
 
     for today in rates_as_dict:
         todays_X = np.full(X_LENGTH, None)

--- a/byn/predict_utils.py
+++ b/byn/predict_utils.py
@@ -9,9 +9,16 @@ import numpy as np
 import byn.constants as const
 from byn.predict.predictor import Predictor, RidgeWeight
 from byn.predict.processor import GlobalToNormlizedDataProcessor
-from byn.cassandra_db import get_accumulated_error
 from byn.datatypes import LocalRates
-from byn.hbase_db import db, bytes_to_date, date_to_next_bytes, table, key_part, get_decimal
+from byn.hbase_db import (
+    db,
+    bytes_to_date,
+    date_to_next_bytes,
+    table,
+    key_part,
+    get_decimal,
+    get_accumulated_error,
+)
 
 
 

--- a/byn/realtime/bcse.py
+++ b/byn/realtime/bcse.py
@@ -135,21 +135,12 @@ async def _extract_and_publish(today, current_records, redis, client):
 
     logger.debug('New bcse data: %s', new_data)
 
-    results = insert_bcse(new_data)
+    insert_bcse(new_data)
 
     if len(new_data) > 0:
         asyncio.create_task(_notify_about_new_bcse(redis, data))
 
-    for r in results:
-        try:
-            r.result()
-        except asyncio.CancelledError as e:
-            raise e
-        except:
-            logger.exception("BCSE rate wasn't saved in cassandra.")
-
-    else:
-        current_records.update([(x.timestamp_operation, x.rate) for x in new_data])
+    current_records.update([(x.timestamp_operation, x.rate) for x in new_data])
 
 
 async def _extract_bcse_rates(client: ClientSession, date: datetime.date) -> Optional[List[List]]:

--- a/byn/realtime/bcse.py
+++ b/byn/realtime/bcse.py
@@ -13,7 +13,8 @@ from aiohttp.client import ClientSession
 from aioredis import Redis
 
 import byn.constants as const
-from byn.cassandra_db import insert_bcse_async, get_bcse_in
+from byn.cassandra_db import get_bcse_in
+from byn.hbase_db import insert_bcse
 from byn.datatypes import BcseData, PredictCommand
 from byn.utils import always_on_coroutine, create_redis
 from byn.realtime.synchronization import (
@@ -138,7 +139,7 @@ async def _extract_and_publish(today, current_records, redis, client):
 
     logger.debug('New bcse data: %s', new_data)
 
-    results = insert_bcse_async(new_data, timeout=1)
+    results = insert_bcse(new_data)
 
     if len(new_data) > 0:
         asyncio.create_task(_notify_about_new_bcse(redis, data))

--- a/byn/realtime/bcse_converter.py
+++ b/byn/realtime/bcse_converter.py
@@ -4,10 +4,9 @@ from itertools import chain
 
 import numpy as np
 
-from byn.cassandra_db import (
+from byn.hbase_db import (
     get_latest_external_rates,
     get_external_rate_live,
-
 )
 from byn.realtime.detailed_rates import RatesDetailedExtractor
 

--- a/byn/realtime/predict_scheduler.py
+++ b/byn/realtime/predict_scheduler.py
@@ -8,7 +8,7 @@ import json
 import logging
 
 from byn import constants as const
-from byn.cassandra_db import (
+from byn.hbase_db import (
     get_the_last_external_rates,
 )
 from byn.datatypes import LocalRates
@@ -25,7 +25,7 @@ async def predict_scheduler():
         const.FOREXPF_CURRENCIES_TO_LISTEN,
         datetime.datetime.now()
     )
-    raw_input_data = {k.lower(): v.open for k, v in raw_input_data.items()}
+    raw_input_data = {k.lower(): v['rate_open'] for k, v in raw_input_data.items()}
 
     while True:
         external_rates = (

--- a/byn/realtime/predict_server.py
+++ b/byn/realtime/predict_server.py
@@ -13,8 +13,7 @@ from byn.predict_utils import build_predictor
 from byn.predict.predictor import Predictor
 from byn.predict.utils import build_trust_array
 from byn.datatypes import LocalRates, PredictCommand
-from byn.cassandra_db import get_bcse_in, insert_prediction_async
-from byn.hbase_db import insert_prediction
+from byn.hbase_db import insert_prediction, get_bcse_in
 from byn.realtime.synchronization import (
     wait_for_data_threads,
     receive_predictor_command,
@@ -47,11 +46,7 @@ async def run():
 
         if predictor.meta.last_date < today:
             start_dt = datetime.datetime.fromordinal(today.toordinal())
-            bcse_data = np.array([
-                (int(dt.timestamp()), Decimal(rate))
-                for dt, rate in
-                get_bcse_in('USD', start_dt=start_dt)
-            ], dtype=np.dtype(object))
+            bcse_data = np.array(get_bcse_in('USD', start_dt=start_dt), dtype=np.dtype(object))
 
             todays_bcse_config.configure(bcse_pairs=bcse_data, rolling_average=rolling_average)
 

--- a/byn/realtime/predict_server.py
+++ b/byn/realtime/predict_server.py
@@ -46,7 +46,10 @@ async def run():
 
         if predictor.meta.last_date < today:
             start_dt = datetime.datetime.fromordinal(today.toordinal())
-            bcse_data = np.array(get_bcse_in('USD', start_dt=start_dt), dtype=np.dtype(object))
+            bcse_data = np.array(
+                tuple(get_bcse_in('USD', start_dt=start_dt)),
+                dtype=np.dtype(object)
+            )
 
             todays_bcse_config.configure(bcse_pairs=bcse_data, rolling_average=rolling_average)
 

--- a/byn/realtime/predict_server.py
+++ b/byn/realtime/predict_server.py
@@ -66,7 +66,7 @@ async def run():
 
             elif command == PredictCommand.NEW_BCSE:
                 bcse_data = np.array([
-                    (ts // 1000, rate) for ts, rate in message['data']['rates']
+                    (ts, rate) for ts, rate in message['data']['rates']
                 ], dtype=np.dtype(object))
 
                 todays_bcse_config.configure(bcse_pairs=bcse_data, rolling_average=rolling_average)

--- a/byn/realtime/predict_server.py
+++ b/byn/realtime/predict_server.py
@@ -14,7 +14,7 @@ from byn.predict.predictor import Predictor
 from byn.predict.utils import build_trust_array
 from byn.datatypes import LocalRates, PredictCommand
 from byn.cassandra_db import get_bcse_in, insert_prediction_async
-from byn.predict.utils import ignore_containing_nan
+from byn.hbase_db import insert_prediction
 from byn.realtime.synchronization import (
     wait_for_data_threads,
     receive_predictor_command,
@@ -84,7 +84,7 @@ async def run():
 
                 await send_prediction(redis, prediction, message_guid=message_guid)
 
-                insert_prediction_async(
+                insert_prediction(
                     timestamp=message_guid,
                     external_rates=data,
                     bcse_full=todays_bcse_config.bcse_full,

--- a/byn/requirements/app.in
+++ b/byn/requirements/app.in
@@ -6,7 +6,8 @@ redis
 scikit-learn
 
 # Communicate with db-s
-cassandra-driver
+cython
+happybase
 aioredis
 
 # Communicate with api-s

--- a/byn/requirements/app.txt
+++ b/byn/requirements/app.txt
@@ -11,20 +11,23 @@ amqp==2.4.1               # via kombu
 async-timeout==3.0.1      # via aiohttp, aioredis
 attrs==18.2.0             # via aiohttp
 billiard==3.5.0.5
-cassandra-driver==3.16.0
 certifi==2018.11.29       # via sentry-sdk
 chardet==3.0.4            # via aiohttp
+cython==0.29.6
+happybase==1.1.0
 hiredis==0.3.1            # via aioredis
 idna==2.8                 # via yarl
 kombu==4.3.0
 multidict==4.5.2          # via aiohttp, yarl
 numpy==1.16.1             # via scikit-learn, scipy
+ply==3.11                 # via thriftpy
 pytz==2018.9
 redis==3.1.0
 scikit-learn==0.20.2
 scipy==1.2.1              # via scikit-learn
 sentry-sdk==0.7.6
-six==1.12.0               # via cassandra-driver
+six==1.12.0               # via happybase
+thriftpy==0.3.9           # via happybase
 urllib3==1.24.1           # via sentry-sdk
 vine==1.2.0               # via amqp
 yarl==1.3.0               # via aiohttp

--- a/byn/requirements/celery.txt
+++ b/byn/requirements/celery.txt
@@ -14,17 +14,19 @@ babel==2.6.0              # via flower
 billiard==3.5.0.5
 boto3==1.9.82
 botocore==1.12.82         # via boto3, s3transfer
-cassandra-driver==3.16.0
 certifi==2018.11.29       # via requests, sentry-sdk
 chardet==3.0.4            # via aiohttp, requests
+cython==0.29.6
 docutils==0.14            # via botocore
 flower==0.9.2
+happybase==1.1.0
 hiredis==0.3.1            # via aioredis
 idna==2.8                 # via requests, yarl
 jmespath==0.9.3           # via boto3, botocore
 kombu==4.2.2.post1
 multidict==4.5.2          # via aiohttp, yarl
 numpy==1.16.0             # via scikit-learn, scipy
+ply==3.11                 # via thriftpy
 python-dateutil==2.7.5    # via botocore
 pytz==2018.9              # via babel, flower
 redis==3.0.1
@@ -33,7 +35,8 @@ s3transfer==0.1.13        # via boto3
 scikit-learn==0.20.2
 scipy==1.2.0              # via scikit-learn
 sentry-sdk==0.7.6
-six==1.12.0               # via cassandra-driver, python-dateutil
+six==1.12.0               # via happybase, python-dateutil
+thriftpy==0.3.9           # via happybase
 tornado==5.1.1            # via flower
 urllib3==1.24.1           # via botocore, requests, sentry-sdk
 vine==1.2.0               # via amqp

--- a/byn/requirements/pytest.txt
+++ b/byn/requirements/pytest.txt
@@ -17,14 +17,15 @@ billiard==3.5.0.5
 bleach==3.1.0             # via nbconvert
 boto3==1.9.82
 botocore==1.12.82         # via boto3, s3transfer
-cassandra-driver==3.16.0
 certifi==2018.11.29       # via requests, sentry-sdk
 chardet==3.0.4            # via aiohttp, requests
+cython==0.29.6
 decorator==4.3.0          # via ipython, traitlets
 defusedxml==0.5.0         # via nbconvert
 docutils==0.14            # via botocore
 entrypoints==0.3          # via nbconvert
 flower==0.9.2
+happybase==1.1.0
 hiredis==0.3.1            # via aioredis
 idna==2.8                 # via requests, yarl
 ipykernel==5.1.0          # via ipywidgets, jupyter, jupyter-console, notebook, qtconsole
@@ -53,6 +54,7 @@ parso==0.3.1              # via jedi
 pexpect==4.6.0            # via ipython
 pickleshare==0.7.5        # via ipython
 pluggy==0.8.1             # via pytest
+ply==3.11                 # via thriftpy
 prometheus-client==0.5.0  # via notebook
 prompt-toolkit==2.0.7     # via ipython, jupyter-console
 ptyprocess==0.6.0         # via pexpect, terminado
@@ -71,9 +73,10 @@ scikit-learn==0.20.2
 scipy==1.2.0              # via scikit-learn
 send2trash==1.5.0         # via notebook
 sentry-sdk==0.7.6
-six==1.12.0               # via bleach, cassandra-driver, more-itertools, prompt-toolkit, pytest, python-dateutil, traitlets
+six==1.12.0               # via bleach, happybase, more-itertools, prompt-toolkit, pytest, python-dateutil, traitlets
 terminado==0.8.1          # via notebook
 testpath==0.4.2           # via nbconvert
+thriftpy==0.3.9           # via happybase
 tornado==5.1.1            # via flower, ipykernel, jupyter-client, notebook, terminado
 traitlets==4.3.2          # via ipykernel, ipython, ipywidgets, jupyter-client, jupyter-core, nbconvert, nbformat, notebook, qtconsole
 urllib3==1.24.1           # via botocore, requests, sentry-sdk

--- a/byn/retry.py
+++ b/byn/retry.py
@@ -1,0 +1,112 @@
+import logging
+from functools import partial, wraps
+from typing import Union, Type, Container
+
+
+logger = logging.getLogger(__name__)
+
+
+def retryable(
+        func=None,
+        expected_exception: Union[Type[Exception], Container[Type[Exception]]]=(),
+        *,
+        retry_count: int=1,
+        callback=None,
+):
+    if func is None:
+        return partial(
+            retryable,
+            expected_exception=expected_exception,
+            retry_count=retry_count,
+            callback=callback
+        )
+
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        i = 0
+
+        prev_exceptions = []
+
+        while True:
+            try:
+                return func(*args, **kwargs)
+            except expected_exception as e:
+                prev_exceptions.append(e)
+                if i >= retry_count:
+                    logger.error(
+                        'Got too many exceptions: %s\nRaising the last one.',
+                        prev_exceptions
+                    )
+                    raise e
+
+                logger.info(
+                    'Got expected exception %s while running %s. %s attempts left.',
+                    type(e).__name__,
+                    func.__name__ if hasattr(func, '__name__') else func,
+                    retry_count - i
+                )
+
+                if callback is not None:
+                    callback(*args, **kwargs)
+
+                i += 1
+
+    return wrapper
+
+
+def retryable_generator(
+        func=None,
+        expected_exception: Union[Type[Exception], Container[Type[Exception]]]=(),
+        *,
+        retry_count: int=1,
+        callback=None,
+):
+    if func is None:
+        return partial(
+            retryable,
+            expected_exception=expected_exception,
+            retry_count=retry_count,
+            callback=callback
+        )
+
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        i = 0
+
+        prev_exceptions = []
+
+        while True:
+            try:
+                object_to_return = func(*args, **kwargs)
+
+                try:
+                    yield next(object_to_return)
+                except StopIteration:
+                    return
+                except GeneratorExit:
+                    pass
+            except expected_exception as e:
+                prev_exceptions.append(e)
+                if i >= retry_count:
+                    logger.error(
+                        'Got too many exceptions: %s\nRaising the last one.',
+                        prev_exceptions
+                    )
+                    raise e
+
+                logger.info(
+                    'Got expected exception %s while running %s. %s attempts left.',
+                    type(e).__name__,
+                    func.__name__ if hasattr(func, '__name__') else func,
+                    retry_count - i
+                )
+
+                if callback is not None:
+                    callback(*args, **kwargs)
+
+                i += 1
+            else:
+                yield from object_to_return
+                return
+
+    return wrapper

--- a/byn/tasks/backup.py
+++ b/byn/tasks/backup.py
@@ -6,8 +6,6 @@ from typing import Tuple
 
 from celery import group
 
-from byn import constants as const
-from byn.cassandra_db import db
 from byn.tasks.launch import app
 
 
@@ -55,6 +53,8 @@ def backup_async():
 
 @app.task
 def _create_cassandra_table_backup(table: str, columns: Tuple[str]):
+    from byn.cassandra_db import db
+
     data = db.execute(f'SELECT {", ".join(columns)} from {table}', timeout=120)
     with gzip.open(f'/tmp/{table}.csv.gz', mode='wt') as f:
         writer = csv.writer(f, delimiter=';')

--- a/byn/tasks/daily_predict.py
+++ b/byn/tasks/daily_predict.py
@@ -4,7 +4,7 @@ from decimal import Decimal
 
 from byn.predict_utils import build_and_predict_linear
 from byn.tasks.launch import app
-from byn.hbase_db import bytes_to_date, get_decimal, next_date_to_bytes, db, key_part
+from byn.hbase_db import bytes_to_date, get_decimal, date_to_next_bytes, db, key_part
 
 
 start_prediction_day = datetime.date(2018, 7, 15)
@@ -28,8 +28,7 @@ def daily_predict():
 
         nbrb = connection.table('nbrb')
         key_to_data = nbrb.scan(
-            prefix='global|',
-            row_start=next_date_to_bytes(start_date),
+            row_start=b'global|' + date_to_next_bytes(start_date),
             columns=[b'rate:byn'],
             filter="SingleColumnValueFilter('rate', 'eur', >, '', true) AND "
                    "SingleColumnValueFilter('rate', 'rub', >, '', true) AND "

--- a/byn/tasks/daily_predict.py
+++ b/byn/tasks/daily_predict.py
@@ -14,13 +14,13 @@ logger = logging.getLogger(__name__)
 @app.task
 def daily_predict():
     with db.connection() as connection:
-        trade_date = connection.table('tarde_date')
+        trade_date = connection.table('trade_date')
 
         last_record = next(trade_date.scan(
             reverse=True,
             columns=[b'rate:accumulated_error'],
             limit=1,
-            filter="SingleColumnValueFilter('rate', 'predicted', >, '', true)",
+            filter="SingleColumnValueFilter('rate', 'predicted', >, 'binary:', true, true)",
         ), None)
 
         start_date = bytes_to_date(last_record[0]) if last_record else start_prediction_day
@@ -30,9 +30,9 @@ def daily_predict():
         key_to_data = nbrb.scan(
             row_start=b'global|' + date_to_next_bytes(start_date),
             columns=[b'rate:byn'],
-            filter="SingleColumnValueFilter('rate', 'eur', >, '', true) AND "
-                   "SingleColumnValueFilter('rate', 'rub', >, '', true) AND "
-                   "SingleColumnValueFilter('rate', 'uah', >, '', true)",
+            filter="SingleColumnValueFilter('rate', 'eur', >, 'binary:', true, true) AND "
+                   "SingleColumnValueFilter('rate', 'rub', >, 'binary:', true, true) AND "
+                   "SingleColumnValueFilter('rate', 'uah', >, 'binary:', true, true)",
         )
 
         new_data = []

--- a/byn/tasks/external_rates.py
+++ b/byn/tasks/external_rates.py
@@ -45,12 +45,7 @@ def extract_one_currency(start_dt: datetime.datetime, currency: str):
 @app.task(autoretry_for=(Exception, ))
 def load_one_currency(currency: str):
     with open(const.EXTERNAL_RATE_DATA % currency, mode='rt') as f:
-        data = json.load(f, parse_float=Decimal)
-
-    for row in data:
-        row[0] = datetime.datetime.fromtimestamp(row[0])
-        for i in (1, 2, 3, 4):
-            row[i] = Decimal(row[i])
+        data = json.load(f, parse_float=str)
 
     insert_external_rates(currency, data)
 

--- a/byn/tasks/external_rates.py
+++ b/byn/tasks/external_rates.py
@@ -5,14 +5,12 @@ Periodical: once a day.
 """
 import datetime
 import json
-from decimal import Decimal
 
 from celery import group
 
 from byn import constants as const
 from byn import forexpf
-from byn.cassandra_db import get_last_external_currency_datetime
-from byn.hbase_db import insert_external_rates
+from byn.hbase_db import insert_external_rates, get_last_external_currency_datetime
 from byn.tasks.launch import app
 
 

--- a/byn/tasks/external_rates.py
+++ b/byn/tasks/external_rates.py
@@ -11,7 +11,8 @@ from celery import group
 
 from byn import constants as const
 from byn import forexpf
-from byn.cassandra_db import insert_external_rates, get_last_external_currency_datetime
+from byn.cassandra_db import get_last_external_currency_datetime
+from byn.hbase_db import insert_external_rates
 from byn.tasks.launch import app
 
 

--- a/byn/tasks/external_rates.py
+++ b/byn/tasks/external_rates.py
@@ -17,7 +17,7 @@ from byn.tasks.launch import app
 RESOLUTIONS = (1, 3, 5, 15, 30, 60, 120)
 
 
-@app.task(autoretry_for=(Exception, ))
+@app.task(autoretry_for=(Exception, ), retry_backoff=True)
 def extract_one_currency(start_dt: datetime.datetime, currency: str):
     end_dt = datetime.datetime.now()
     data_to_store = []
@@ -41,7 +41,7 @@ def extract_one_currency(start_dt: datetime.datetime, currency: str):
         json.dump(data_to_store, f)
 
 
-@app.task(autoretry_for=(Exception, ))
+@app.task(autoretry_for=(Exception, ), retry_backoff=True)
 def load_one_currency(currency: str):
     with open(const.EXTERNAL_RATE_DATA % currency, mode='rt') as f:
         data = json.load(f, parse_float=str)

--- a/byn/tasks/launch.py
+++ b/byn/tasks/launch.py
@@ -28,7 +28,7 @@ app.conf.beat_schedule = {
         'schedule': crontab(minute=0, hour=1),
     },
     'backup': {
-        'task': 'byn.tasks.backup.backup_async',
+        'task': 'byn.tasks.backup.hbase_backup_async',
         'schedule': crontab(minute=30, hour=1),
     },
 }

--- a/byn/tasks/nbrb.py
+++ b/byn/tasks/nbrb.py
@@ -78,7 +78,10 @@ def update_nbrb_rates_async(need_last_date=True):
     )()
 
 
-@app.task
+@app.task(
+    autoretry_for=(Exception, ),
+    retry_backoff=True,
+)
 def load_trade_dates() -> Sequence[str]:
     dates = client.get(TRADE_DATES_URL).json()
     insert_trade_dates(dates)
@@ -132,7 +135,10 @@ def extract_nbrb(last_trade_dates: Sequence[str], need_last_date=False) -> Itera
 
 
 
-@app.task
+@app.task(
+    autoretry_for=(Exception, ),
+    retry_backoff=True,
+)
 def load_dxy_12MSK() -> Tuple[Iterable]:
     record = get_last_nbrb_record(NbrbKind.GLOBAL)
     date = record and key_part_as_date(record[0], 1)

--- a/byn/tasks/nbrb.py
+++ b/byn/tasks/nbrb.py
@@ -175,9 +175,9 @@ def load_nbrb_local() -> Tuple[dict]:
     data = tuple({
         'date': key_part(x[0], 1),
         'USD': get_decimal(x[1], b'rate:usd'),
-        'EUR': get_decimal(x[1], b'rate:eur') / get_decimal(x[1], b'rate:usd'),
-        'RUB': get_decimal(x[1], b'rate:rub') / get_decimal(x[1], b'rate:rub') * 100,
-        'UAH': get_decimal(x[1], b'rate:uah') / get_decimal(x[1], b'rate:uah') * 100,
+        'EUR': get_decimal(x[1], b'rate:usd') / get_decimal(x[1], b'rate:eur'),
+        'RUB': get_decimal(x[1], b'rate:usd') / get_decimal(x[1], b'rate:rub') * 100,
+        'UAH': get_decimal(x[1], b'rate:usd') / get_decimal(x[1], b'rate:uah') * 100,
     } for x in clean_data)
     insert_nbrb_local(data)
     return data

--- a/byn/tasks/nbrb.py
+++ b/byn/tasks/nbrb.py
@@ -158,7 +158,7 @@ def load_dxy_12MSK() -> Tuple[Iterable]:
 
     timestamps = [[datetime.datetime(x.year, x.month, x.day, 12).timestamp()] for x in dates]
     dates = [x.isoformat() for x in dates]
-    rate_pairs = tuple(zip(dates, [Decimal(x) for x in dxy_regressor.predict(timestamps)]))
+    rate_pairs = tuple(zip(dates, [str(x) for x in dxy_regressor.predict(timestamps)]))
 
     insert_dxy_12MSK(rate_pairs)
 
@@ -265,10 +265,3 @@ def nbrb_file_to_cassandra():
         data = json.load(f)
 
     load_nbrb(data)
-
-
-def dxy_12MSK_to_cassandra():
-    with open(const.DXY_12MSK_DARA, mode='rt') as f:
-        data = json.load(f)
-
-    insert_dxy_12MSK([(x[0], Decimal(x[1])) for x in data])

--- a/byn/tasks/nbrb.py
+++ b/byn/tasks/nbrb.py
@@ -30,12 +30,14 @@ from byn.cassandra_db import (
     get_nbrb_gt,
     get_nbrb_local_gt,
     get_nbrb_global_gt,
-    insert_trade_dates,
-    insert_nbrb_rates,
-    insert_nbrb_local,
+)
+from byn.hbase_db import (
     add_nbrb_global,
-    insert_dxy_12MSK,
+    insert_nbrb,
+    insert_nbrb_local,
+    insert_trade_dates,
     insert_rolling_average,
+    insert_dxy_12MSK,
 )
 from byn.utils import create_redis
 from byn.realtime.synchronization import send_predictor_command
@@ -215,7 +217,7 @@ def load_nbrb(rates):
         rates['date'] = date
 
     data = tuple(cass_rates.values())
-    insert_nbrb_rates(data)
+    insert_nbrb(data)
     return data
 
 

--- a/byn/tests/tasks/test_nbrb.py
+++ b/byn/tests/tasks/test_nbrb.py
@@ -4,7 +4,7 @@ from unittest import mock
 from byn.tasks import nbrb
 
 
-@mock.patch('byn.tasks.nbrb.insert_nbrb_rates')
+@mock.patch('byn.tasks.nbrb.insert_nbrb')
 def test_load_nbrb(patched):
     source = [
         {"Date": "2015-11-02", "cur": "USD", "rate": "1.7421"},

--- a/byn/tests/test_retry.py
+++ b/byn/tests/test_retry.py
@@ -2,13 +2,13 @@ from unittest import mock
 
 import pytest
 
-from byn import utils
+from byn import retry
 
 
 
 def test_retryable__once():
     real_method = mock.Mock(side_effect=[ValueError, 42])
-    f = utils.retryable(real_method, ValueError)
+    f = retry.retryable(real_method, ValueError)
 
     assert f(202, '03') == 42
 
@@ -19,7 +19,7 @@ def test_retryable__once():
 def test_retryable__once_with_callback():
     callback_method = mock.Mock()
     real_method = mock.Mock(side_effect=[ValueError, 42])
-    f = utils.retryable(real_method, ValueError, callback=callback_method)
+    f = retry.retryable(real_method, ValueError, callback=callback_method)
 
     assert f(202, '03') == 42
 
@@ -30,7 +30,7 @@ def test_retryable__once_with_callback():
 
 def test_retryable__twice_error():
     real_method = mock.Mock(side_effect=[ValueError, ValueError, 42])
-    f = utils.retryable(real_method, ValueError)
+    f = retry.retryable(real_method, ValueError)
 
     with pytest.raises(ValueError):
         f(202, '03')
@@ -41,7 +41,7 @@ def test_retryable__twice_error():
 
 def test_retryable__once_but_different():
     real_method = mock.Mock(side_effect=[NotImplementedError, 42])
-    f = utils.retryable(real_method, ValueError)
+    f = retry.retryable(real_method, ValueError)
 
     with pytest.raises(NotImplementedError):
         f(202, '03')
@@ -52,7 +52,7 @@ def test_retryable__once_but_different():
 def test_retryable__twice_error_still_working():
     callback_method = mock.Mock()
     real_method = mock.Mock(side_effect=[ValueError, ValueError, 42])
-    f = utils.retryable(real_method, ValueError, retry_count=2, callback=callback_method)
+    f = retry.retryable(real_method, ValueError, retry_count=2, callback=callback_method)
 
     assert f(202, '03') == 42
 
@@ -63,7 +63,7 @@ def test_retryable__twice_error_still_working():
 
 def test_retryable__different_errors_still_working():
     real_method = mock.Mock(side_effect=[NotImplementedError, ValueError, 42])
-    f = utils.retryable(real_method, (ValueError, NotImplementedError), retry_count=2)
+    f = retry.retryable(real_method, (ValueError, NotImplementedError), retry_count=2)
 
     assert f(202, '03') == 42
 

--- a/byn/tests/test_utils.py
+++ b/byn/tests/test_utils.py
@@ -16,6 +16,18 @@ def test_retryable__once():
     real_method.assert_called_with(202, '03')
 
 
+def test_retryable__once_with_callback():
+    callback_method = mock.Mock()
+    real_method = mock.Mock(side_effect=[ValueError, 42])
+    f = utils.retryable(real_method, ValueError, callback=callback_method)
+
+    assert f(202, '03') == 42
+
+    assert real_method.call_count == 2
+    callback_method.assert_called_once_with(202, '03')
+    real_method.assert_called_with(202, '03')
+
+
 def test_retryable__twice_error():
     real_method = mock.Mock(side_effect=[ValueError, ValueError, 42])
     f = utils.retryable(real_method, ValueError)
@@ -38,12 +50,14 @@ def test_retryable__once_but_different():
 
 
 def test_retryable__twice_error_still_working():
+    callback_method = mock.Mock()
     real_method = mock.Mock(side_effect=[ValueError, ValueError, 42])
-    f = utils.retryable(real_method, ValueError, retry_count=2)
+    f = utils.retryable(real_method, ValueError, retry_count=2, callback=callback_method)
 
     assert f(202, '03') == 42
 
     assert real_method.call_count == 3
+    assert callback_method.call_count == 2
     real_method.assert_called_with(202, '03')
 
 

--- a/byn/tests/test_utils.py
+++ b/byn/tests/test_utils.py
@@ -1,0 +1,58 @@
+from unittest import mock
+
+import pytest
+
+from byn import utils
+
+
+
+def test_retryable__once():
+    real_method = mock.Mock(side_effect=[ValueError, 42])
+    f = utils.retryable(real_method, ValueError)
+
+    assert f(202, '03') == 42
+
+    assert real_method.call_count == 2
+    real_method.assert_called_with(202, '03')
+
+
+def test_retryable__twice_error():
+    real_method = mock.Mock(side_effect=[ValueError, ValueError, 42])
+    f = utils.retryable(real_method, ValueError)
+
+    with pytest.raises(ValueError):
+        f(202, '03')
+
+    assert real_method.call_count == 2
+    real_method.assert_called_with(202, '03')
+
+
+def test_retryable__once_but_different():
+    real_method = mock.Mock(side_effect=[NotImplementedError, 42])
+    f = utils.retryable(real_method, ValueError)
+
+    with pytest.raises(NotImplementedError):
+        f(202, '03')
+
+    real_method.assert_called_once_with(202, '03')
+
+
+def test_retryable__twice_error_still_working():
+    real_method = mock.Mock(side_effect=[ValueError, ValueError, 42])
+    f = utils.retryable(real_method, ValueError, retry_count=2)
+
+    assert f(202, '03') == 42
+
+    assert real_method.call_count == 3
+    real_method.assert_called_with(202, '03')
+
+
+def test_retryable__different_errors_still_working():
+    real_method = mock.Mock(side_effect=[NotImplementedError, ValueError, 42])
+    f = utils.retryable(real_method, (ValueError, NotImplementedError), retry_count=2)
+
+    assert f(202, '03') == 42
+
+    assert real_method.call_count == 3
+    real_method.assert_called_with(202, '03')
+

--- a/byn/utils.py
+++ b/byn/utils.py
@@ -7,7 +7,6 @@ import time
 from decimal import Decimal
 from enum import Enum
 from functools import wraps, partial
-from typing import Container, Iterable, Union, Type
 
 import aioredis
 
@@ -120,63 +119,5 @@ class DecimalAwareEncoder(json.JSONEncoder):
         return super().default(o)
 
 
-def retryable(
-        func=None,
-        expected_exception: Union[Type[Exception], Container[Type[Exception]]]=(),
-        *,
-        retry_count: int=1,
-        callback=None,
-):
-    if func is None:
-        return partial(
-            retryable,
-            expected_exception=expected_exception,
-            retry_count=retry_count,
-            callback=callback
-        )
 
-    @wraps(func)
-    def wrapper(*args, **kwargs):
-        i = 0
-
-        prev_exceptions = []
-
-        while True:
-            try:
-                object_to_return = func(*args, **kwargs)
-
-                if isinstance(object_to_return, Iterable):
-                    try:
-                        yield next(object_to_return)
-                    except StopIteration:
-                        return
-                    except GeneratorExit:
-                        pass
-                else:
-                    return object_to_return
-            except expected_exception as e:
-                prev_exceptions.append(e)
-                if i >= retry_count:
-                    logger.error(
-                        'Got too many exceptions: %s\nRaising the last one.',
-                        prev_exceptions
-                    )
-                    raise e
-
-                logger.info(
-                    'Got expected exception %s while running %s. %s attempts left.',
-                    type(e).__name__,
-                    func.__name__ if hasattr(func, '__name__') else func,
-                    retry_count - i
-                )
-
-                if callback is not None:
-                    callback(*args, **kwargs)
-
-                i += 1
-            else:
-                yield from object_to_return
-                return
-
-    return wrapper
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       - ./nginx.conf:/etc/nginx/conf.d/default.conf:ro
     depends_on:
       - python
+      - celery
 
   python:
     build:
@@ -21,25 +22,15 @@ services:
       - CELERY_BROKER_URL=redis://redis
       - CELERY_RESULT_BACKEND=redis://redis
       - REDIS_URL=redis://redis
-#      - CASSANDRA_HOSTS=cassandra_1,cassandra_2
-#      - CASSANDRA_PORT=9042
-#      - CASSANDRA_NODE_COUNT=${CASSANDRA_NODE_COUNT:-2}
       - HBASE_HOST=${HBASE_HOST:-hbase-master}
       - BACKUP_BUCKET=${BACKUP_BUCKET:-byn-dzmitry-by-backup}
       - SENTRY_DSN=${SENTRY_DSN}
       - SENTRY_ENVIRONMENT=${SENTRY_ENVIRONMENT}
 
-    depends_on:
-      - celery
-    cpus: 0.2
+    cpus: 0.5
     mem_limit: 128m
     memswap_limit: 256m
 
-
-  redis:
-    image: "redis:5-alpine3.8"
-    ports:
-      - "${HOST_REDIS_PORT:-6379}:6379"
 
   celery:
     build:
@@ -65,36 +56,23 @@ services:
       - SENTRY_DSN=${SENTRY_DSN}
       - SENTRY_ENVIRONMENT=${SENTRY_ENVIRONMENT}
     depends_on:
-      - cassandra_1
-      - cassandra_2
+      - hbase-master
       - redis
-    cpus: 0.2
+    cpus: 0.5
     mem_limit: 128m
     memswap_limit: 256m
-  
 
-  cassandra_1:
-    image: "cassandra:3.11"
+  redis:
+    image: "redis:5-alpine3.8"
     ports:
-      - "19042:9042/tcp"
-    environment:
-      - CASSANDRA_SEEDS=cassandra_2
-      - CASSANDRA_CLUSTER_NAME=byn
-    volumes:
-      - ./mount/cassandra_1:/var/lib/cassandra
-    cpus: 0.5
-    mem_limit: 512m
-    memswap_limit: 512m
+      - "${HOST_REDIS_PORT:-6379}:6379"
 
-  cassandra_2:
-    image: "cassandra:3.11"
+  hbase-master:
+    image: "dajobe/hbase"
     ports:
-      - "29042:9042/tcp"
-    environment:
-      - CASSANDRA_SEEDS=cassandra_1
-      - CASSANDRA_CLUSTER_NAME=byn
+      - "16010:16010"
     volumes:
-      - ./mount/cassandra_2:/var/lib/cassandra
+      - ./mount/hbase-master:/var/lib/cassandra
     cpus: 0.5
     mem_limit: 512m
     memswap_limit: 512m

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,9 +21,10 @@ services:
       - CELERY_BROKER_URL=redis://redis
       - CELERY_RESULT_BACKEND=redis://redis
       - REDIS_URL=redis://redis
-      - CASSANDRA_HOSTS=cassandra_1,cassandra_2
-      - CASSANDRA_PORT=9042
-      - CASSANDRA_NODE_COUNT=${CASSANDRA_NODE_COUNT:-2}
+#      - CASSANDRA_HOSTS=cassandra_1,cassandra_2
+#      - CASSANDRA_PORT=9042
+#      - CASSANDRA_NODE_COUNT=${CASSANDRA_NODE_COUNT:-2}
+      - HBASE_HOST=${HBASE_HOST:-hbase-master}
       - BACKUP_BUCKET=${BACKUP_BUCKET:-byn-dzmitry-by-backup}
       - SENTRY_DSN=${SENTRY_DSN}
       - SENTRY_ENVIRONMENT=${SENTRY_ENVIRONMENT}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,9 +45,7 @@ services:
       - CELERY_BROKER_URL=redis://redis
       - CELERY_RESULT_BACKEND=redis://redis
       - REDIS_URL=redis://redis
-      - CASSANDRA_HOSTS=cassandra_1,cassandra_2
-      - CASSANDRA_PORT=9042
-      - CASSANDRA_NODE_COUNT=${CASSANDRA_NODE_COUNT:-2}
+      - HBASE_HOST=${HBASE_HOST:-hbase-master}
       - C_FORCE_ROOT=true
       - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,9 +70,10 @@ services:
   hbase-master:
     image: "dajobe/hbase"
     ports:
+      - "9090:9090"
       - "16010:16010"
     volumes:
-      - ./mount/hbase-master:/var/lib/cassandra
+      - ./mount/hbase-master:/data
     cpus: 0.5
     mem_limit: 512m
     memswap_limit: 512m


### PR DESCRIPTION
Trying to switch from cassandra to hbase data storage as cassandra takes too long to restart in a limited-memory environment.
Disadvatages of the current hbase solution:
1) `happybase` is poorly maintained. `cython` dependency is missing, `thrift` dependency is outdated.
2) `happybase` neither makes heartbit requests nor has a retry logic.
3) `happybase` doesn't have async (callback-based) option for commands.
4) There is no official hbase docker image.
5) I haven't found a way to emulate hbase cluster as easy as it was with cassandra.

Advantages:
1) It looks like you don't have to worry about partitions when making `scan`.
2) Just a new experience. 

